### PR TITLE
Changed URL of Santa Cruz Resistance Community.

### DIFF
--- a/scz/index.html
+++ b/scz/index.html
@@ -1,6 +1,6 @@
 ---
 layout: redirect
 title: Santa Cruz Resistance
-redirectUrl: https://plus.google.com/105682107762020127694/about
+redirectUrl: https://plus.google.com/u/1/+IngressSantaCruzResistance/about
 ---
 


### PR DESCRIPTION
The old 2-step method (with a public info page on G+ and then a "PR"
account) was confusing and led to a lot of people not getting any
response from us. The new link is directly to the G+ page of the Santa
Cruz Resistance account. The old public info page will eventually be
done away with.
