### PR TITLE
Santa Cruz update from Kusum Tracy

### DIFF
--- a/_data/contacts.yaml
+++ b/_data/contacts.yaml
@@ -47,8 +47,8 @@
   area: Peninsula, East Bay
   form: http://sfbay.resists.org/pen/
 
-- agent: Techknow
-  email: ingressslug@gmail.com
+- agent: Santa Cruz Co Resistance
+  email: ingress.sc.county.resistance@gmail.com
   area: Santa Cruz
   form: http://sfbay.resists.org/scz/
 


### PR DESCRIPTION
Kusum Tracy sent this update to me:
under community coords remove TechKnow and replace with
SantaCruzCoRes = ingress.sc.county.resistance@gmail.com